### PR TITLE
add a client certificate with a few extra name types

### DIFF
--- a/x509-test-certs/src/lib.rs
+++ b/x509-test-certs/src/lib.rs
@@ -133,6 +133,38 @@ pub mod good_certs2 {
         include_bytes!("../static-certs/good_certs2/client_cert.der");
 }
 
+pub mod good_certs3 {
+    //! A client certificate with additional name types.
+    //!
+    //! The certificates can be used to test successful client certificate decoding and authorization.
+    //!
+    //! The keys are RSA (2048 bit) and digests are SHA-256.
+    //!
+    //! The client certificate contains a Subject Alternative Name extension containing
+    //! three names: a common name, a serial number, and a role.
+    //!
+
+    /// The root private key, in PEM format.
+    pub const ROOT_KEY_PEM: &[u8] = include_bytes!("../static-certs/good_certs3/root_key.pem");
+    /// The root private key, in DER format.
+    pub const ROOT_KEY_DER: &[u8] = include_bytes!("../static-certs/good_certs3/root_key.der");
+    /// The root certificate, in PEM format.
+    pub const ROOT_CERT_PEM: &[u8] = include_bytes!("../static-certs/good_certs3/root_cert.pem");
+    /// The root certificate, in DER format.
+    pub const ROOT_CERT_DER: &[u8] = include_bytes!("../static-certs/good_certs3/root_cert.der");
+
+    /// The client private key, in PEM format.
+    pub const CLIENT_KEY_PEM: &[u8] = include_bytes!("../static-certs/good_certs3/client_key.pem");
+    /// The client private key, in DER format.
+    pub const CLIENT_KEY_DER: &[u8] = include_bytes!("../static-certs/good_certs3/client_key.der");
+    /// The client certificate, in PEM format.
+    pub const CLIENT_CERT_PEM: &[u8] =
+        include_bytes!("../static-certs/good_certs3/client_cert.pem");
+    /// The client certificate, in DER format.
+    pub const CLIENT_CERT_DER: &[u8] =
+        include_bytes!("../static-certs/good_certs3/client_cert.der");
+}
+
 pub mod bad_certs1 {
     //! CA and improperly signed server certificates.
     //!

--- a/x509-test-gen/Cargo.toml
+++ b/x509-test-gen/Cargo.toml
@@ -11,4 +11,5 @@ name = "regenerate-crate-certs"
 path = "examples/regenerate_crate_certs.rs"
 
 [dependencies]
-openssl = { version = "0.10.52" }
+asn1 = "0.15.2"
+openssl = "0.10.52"

--- a/x509-test-gen/src/generate.rs
+++ b/x509-test-gen/src/generate.rs
@@ -1,10 +1,10 @@
-use openssl::asn1::{Asn1Integer, Asn1Time};
+use openssl::asn1::{Asn1Integer, Asn1Object, Asn1OctetString, Asn1Time};
 use openssl::bn::BigNum;
 use openssl::hash::MessageDigest;
 use openssl::nid::Nid;
 use openssl::pkey::{PKey, Private};
 use openssl::rsa::Rsa;
-use openssl::x509::{extension, X509Builder, X509Name, X509NameBuilder, X509};
+use openssl::x509::{extension, X509Builder, X509Extension, X509Name, X509NameBuilder, X509};
 
 /// A cryptographic key used for signing certificates
 ///
@@ -265,6 +265,19 @@ impl CertBuilder {
             .build(&context)
             .unwrap();
         self.builder.append_extension(subject_alt_name).unwrap();
+        self
+    }
+
+    /// Add a Subject Alternative Name field containing a serial number.
+    ///
+    /// This might be useful in a client certificate.
+    pub fn subject_alternative_name_raw(mut self, raw: &[u8]) -> Self {
+        let der_bytes = Asn1OctetString::new_from_bytes(raw).unwrap();
+
+        let oid = Asn1Object::from_str("2.5.29.17").unwrap();
+
+        let ext = X509Extension::new_from_der(&oid, true, &der_bytes).unwrap();
+        self.builder.append_extension(ext).unwrap();
         self
     }
 

--- a/x509-test-gen/src/lib.rs
+++ b/x509-test-gen/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tools for creating X509 test certificates.
 
 mod generate;
+pub mod san;
 
 pub use generate::{
     create_client_cert, create_intermediate_cert, create_root_cert, create_server_cert, Cert,

--- a/x509-test-gen/src/san.rs
+++ b/x509-test-gen/src/san.rs
@@ -1,0 +1,78 @@
+//! Subject Alternative Names
+//!
+//! An example of generating custom Subject Alternative Name types, beyond
+//! what the openssl crate allows.
+
+use asn1::{oid, Asn1Writable, Explicit, ObjectIdentifier, SetOfWriter, Utf8String};
+
+#[derive(asn1::Asn1Write, asn1::Asn1Read)]
+struct Stringy<'a> {
+    oid: ObjectIdentifier,
+    s: Utf8String<'a>,
+}
+
+#[derive(asn1::Asn1Write)]
+struct SetStringy<'a> {
+    inner: SetOfWriter<'a, Stringy<'a>>,
+}
+
+/// A collection of names used in generating a Subject Alternative Name extension.
+pub struct SubjectAltName {
+    /// A common name.
+    pub common_name: Option<String>,
+    /// A serial number.
+    pub serial_number: Option<String>,
+    /// A role.
+    pub role: Option<String>,
+}
+
+const OID_COMMON_NAME: ObjectIdentifier = oid!(2, 5, 4, 3);
+const OID_SERIAL_NUMBER: ObjectIdentifier = oid!(2, 5, 4, 5);
+const OID_ROLE: ObjectIdentifier = oid!(2, 5, 4, 72);
+
+impl SubjectAltName {
+    /// Return `SubjectAltName` contents as DER-encoded bytes.
+    ///
+    /// For use with openssl `X509Extension::new_from_der()`.
+    pub fn as_asn1_bytes(&self) -> Option<Vec<u8>> {
+        asn1::write_single(self).ok()
+    }
+}
+
+impl Asn1Writable for SubjectAltName {
+    fn write(&self, w: &mut asn1::Writer) -> asn1::WriteResult {
+        w.write_element(&asn1::SequenceWriter::new(&|w| {
+            if let Some(common_name) = &self.common_name {
+                let common_name = [Stringy {
+                    oid: OID_COMMON_NAME,
+                    s: Utf8String::new(common_name),
+                }];
+                let common_name: Explicit<_, 4> = Explicit::new(SetStringy {
+                    inner: SetOfWriter::new(&common_name),
+                });
+                w.write_element(&common_name)?;
+            }
+            if let Some(serial_number) = &self.serial_number {
+                let serial = [Stringy {
+                    oid: OID_SERIAL_NUMBER,
+                    s: Utf8String::new(serial_number),
+                }];
+                let serial: Explicit<_, 4> = Explicit::new(SetStringy {
+                    inner: SetOfWriter::new(&serial),
+                });
+                w.write_element(&serial)?;
+            }
+            if let Some(role) = &self.role {
+                let role = [Stringy {
+                    oid: OID_ROLE,
+                    s: Utf8String::new(role),
+                }];
+                let role: Explicit<_, 4> = Explicit::new(SetStringy {
+                    inner: SetOfWriter::new(&role),
+                });
+                w.write_element(&role)?;
+            }
+            Ok(())
+        }))
+    }
+}


### PR DESCRIPTION
The openssl crate does not support directory names in the Subject Alternative Name extension, so this is done the hard way by manually constructing the ASN1-encoded extension payload.